### PR TITLE
Add stock existence check

### DIFF
--- a/src/components/AddStockModal.tsx
+++ b/src/components/AddStockModal.tsx
@@ -9,7 +9,7 @@ import {
     Alert,
 } from '@mui/material';
 import { addUserStock } from '../service/UserServices';
-import { getCompanyProfile } from '../service/StockServices';
+import { checkIfStockIsAlreadyAdded, getCompanyProfile } from '../service/StockServices';
 
 const style = {
     position: 'absolute',
@@ -82,6 +82,13 @@ const AddStockModal = ({ open, handleClose, handleAddStock }: AddStockModalProps
         if (selectedStock && sharesOwned) {
             setLoading(true);
             try {
+                const response = await checkIfStockIsAlreadyAdded(selectedStock.ticker);
+                if (response.data === true) {
+                    setError('Stock already exists in your portfolio');
+                    setLoading(false);
+                    return;
+                }
+
                 await addUserStock(selectedStock.ticker, selectedStock.name, parseFloat(sharesOwned), parseFloat(costBasis));
 
                 // Close modal and reset states

--- a/src/components/AddStockModal.tsx
+++ b/src/components/AddStockModal.tsx
@@ -84,7 +84,7 @@ const AddStockModal = ({ open, handleClose, handleAddStock }: AddStockModalProps
             try {
                 const response = await checkIfStockIsAlreadyAdded(selectedStock.ticker);
                 if (response.data === true) {
-                    setError('Stock already exists in your portfolio');
+                    setError(`${selectedStock.ticker} already exists in your portfolio`);
                     setLoading(false);
                     return;
                 }

--- a/src/service/StockServices.tsx
+++ b/src/service/StockServices.tsx
@@ -24,3 +24,7 @@ export const getIndicesData = async () => {
 export const getStockNews = async (symbol: any) => {
     return api.get('/stockData/stockNews?symbol=' + symbol)
 }
+
+export const checkIfStockIsAlreadyAdded = async (symbol: any) => {
+    return api.get('/stockData/stockExistsInDB?symbol=' + symbol)
+}


### PR DESCRIPTION
This pull request includes changes to the `AddStockModal` component and the `StockServices` service to add a feature that checks if a stock is already added to the user's portfolio before allowing it to be added again. The most important changes include importing the new service function, adding the check in the modal, and defining the new service function.

Changes to `AddStockModal` component:

* [`src/components/AddStockModal.tsx`](diffhunk://#diff-3fa93af777fc5420862d22aa9c89d3852394cc8d5dfd49e6ed4e30f460bcf7ebL12-R12): Imported the `checkIfStockIsAlreadyAdded` function from `StockServices`.
* [`src/components/AddStockModal.tsx`](diffhunk://#diff-3fa93af777fc5420862d22aa9c89d3852394cc8d5dfd49e6ed4e30f460bcf7ebR85-R91): Added a check to see if the stock is already in the user's portfolio, displaying an error message if it is.

Changes to `StockServices` service:

* [`src/service/StockServices.tsx`](diffhunk://#diff-c1886419c8debb052547004b8016ba5995f8ce91a93145c0b19f6c13d8ed3ea6R27-R30): Defined the `checkIfStockIsAlreadyAdded` function to call the API endpoint that checks if a stock exists in the database.